### PR TITLE
delete orders button connected and functioning

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -1,5 +1,5 @@
-import { getSingleItem } from './itemData';
-import { getSingleOrder } from './orderData';
+import { deleteItem, getSingleItem } from './itemData';
+import { deleteSingleOrder, getSingleOrder } from './orderData';
 import getOrderItems from './orderItemsData';
 
 const getOrderAndItems = async (orderFirebaseKey) => {
@@ -16,4 +16,11 @@ const getOrderAndItems = async (orderFirebaseKey) => {
   return { ...order, items: itemsInOrder };
 };
 
-export default getOrderAndItems;
+const deleteOrderItemsRelationship = async (ordersFirebaseKey) => {
+  const orderItems = await getOrderItems(ordersFirebaseKey);
+  const deleteItemPromises = await orderItems.map((abObj) => deleteItem(abObj.firebaseKey));
+
+  await Promise.all(deleteItemPromises).then(() => deleteSingleOrder(ordersFirebaseKey));
+};
+
+export { getOrderAndItems, deleteOrderItemsRelationship };

--- a/api/orderData.js
+++ b/api/orderData.js
@@ -35,4 +35,17 @@ const getSingleOrder = (firebaseKey) => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
-export { getOrders, getSingleOrder };
+// Delete Order
+const deleteSingleOrder = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/orders/${firebaseKey}.json`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
+export { getOrders, getSingleOrder, deleteSingleOrder };

--- a/api/orderItemsData.js
+++ b/api/orderItemsData.js
@@ -2,6 +2,7 @@ import client from '../utils/client';
 
 const endpoint = client.databaseURL;
 
+// Get a single order's items
 const getOrderItems = (orderFirebaseKey) => new Promise((resolve, reject) => {
   fetch(`${endpoint}/orderItems.json?orderBy="order_id"&equalTo="${orderFirebaseKey}"`, {
     method: 'GET',

--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -1,4 +1,4 @@
-import getOrderAndItems from '../api/mergedData';
+import { getOrderAndItems, deleteOrderItemsRelationship } from '../api/mergedData';
 import { getOrders } from '../api/orderData';
 import { showOrders } from '../pages/orders';
 import viewOrderItems from '../pages/viewOrderItems';
@@ -14,6 +14,15 @@ const domEvents = (uid) => {
       const [, firebaseKey] = e.target.id.split('--');
 
       getOrderAndItems(firebaseKey).then(viewOrderItems);
+    }
+
+    // Click Event for deleting an Order
+    if (e.target.id.includes('delete-order-btn')) {
+      const [, firebaseKey] = e.target.id.split('--');
+
+      deleteOrderItemsRelationship(firebaseKey).then(() => {
+        getOrders(uid).then(showOrders);
+      });
     }
   });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Created delete order items function and connected delete order button.

## Description
Updated  delete Item API Call, created deleteOrderItemsRelationship merged call, created a getOrderItems promise, created deleteItem API call. Delete button on orders now deletes entire order and items within.

## Related Issue

## Motivation and Context
Needed ability to delete cancelled/wrong orders.

## How Can This Be Tested?
Click the delete button on orders!

## Screenshots (if appropriate):
![test](https://github.com/nss-evening-cohort-26/pos-terminal-the-algorithm-avengers/assets/153697028/aa22260e-579c-4441-b750-807bf40ed619)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
