### PR TITLE
cards can toggle based on order status

### DIFF
--- a/components/shared/domBuilder.js
+++ b/components/shared/domBuilder.js
@@ -3,7 +3,9 @@ import renderToDom from '../../utils/renderToDom';
 const domBuilder = () => {
   const domString = `
   <div id="navigation"></div>
+  <div id="filter-btn"></div>
   <div id="main-container">
+    <div id="store-and-filter"></div>
     <div id="store"></div>
     <div id="view"></div>
     <div id="form-container"></div>

--- a/components/shared/filterCards.js
+++ b/components/shared/filterCards.js
@@ -1,0 +1,20 @@
+import renderToDom from '../../utils/renderToDom';
+import clearDom from '../../utils/clearDom';
+
+const filterCardsStatus = () => {
+  clearDom();
+  const domString = `
+  <div class="dropdown-center" style="margin: 10px; display: flex;
+  flex-direction: row;">
+  <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+    Filter By
+  </button>
+  <ul class="dropdown-menu">
+    <li><a class="dropdown-item" href="#" id="openOrder">Open</a></li>
+    <li><a class="dropdown-item" href="#" id="closedOrder">Closed</a></li>
+  </ul>
+  </div>`;
+  renderToDom('#filter-btn', domString);
+};
+
+export default filterCardsStatus;

--- a/events/orderFilterStatusBtn.js
+++ b/events/orderFilterStatusBtn.js
@@ -1,0 +1,20 @@
+import { getOrders } from '../api/orderData';
+import { showOrders } from '../pages/orders';
+
+const orderFilterStatusBtn = (uid) => {
+  document.querySelector('#filter-btn').addEventListener('click', async (e) => {
+    const ordered = await getOrders(uid);
+    if (e.target.id.includes('openOrder')) {
+      const orderOpen = ordered.filter((open) => open.status === true);
+      console.warn(orderOpen);
+      showOrders(orderOpen, uid);
+    }
+    if (e.target.id.includes('closedOrder')) {
+      const orderClosed = ordered.filter((open) => open.status === false);
+      console.warn(orderClosed);
+      showOrders(orderClosed, uid);
+    }
+  });
+};
+
+export default orderFilterStatusBtn;

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -1,3 +1,4 @@
+import filterCardsStatus from '../components/shared/filterCards';
 import clearDom from '../utils/clearDom';
 import renderToDOM from '../utils/renderToDom';
 
@@ -11,6 +12,7 @@ const showOrders = (array) => {
   if (array.length <= 0) {
     emptyOrders();
   } else {
+    filterCardsStatus();
     let domString = '<div class="order-container">';
     array.forEach((order) => {
       domString += `

--- a/utils/clearDom.js
+++ b/utils/clearDom.js
@@ -2,6 +2,7 @@ const clearDom = () => {
   document.querySelector('#store').innerHTML = '';
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#form-container').innerHTML = '';
+  document.querySelector('#filter-btn').innerHTML = '';
 };
 
 export default clearDom;

--- a/utils/startApp.js
+++ b/utils/startApp.js
@@ -5,11 +5,13 @@ import navBar from '../components/shared/nav';
 import domEvents from '../events/domEvents';
 import formEvents from '../events/formEvents';
 import navEvents from '../events/navEvents';
+import orderFilterStatusBtn from '../events/orderFilterStatusBtn';
 
 const startApp = (uid, displayName) => {
   domBuilder();
   domEvents(uid);
   formEvents(uid);
+  orderFilterStatusBtn(uid);
   navBar();
   homeLoggedIn(displayName);
   navEvents(uid);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
- created filterCards.js that held the html that renders the drop-down btn selection. 
- Made sure it rendered to the div that I created for filter-btn in the dom builder folder
- I added the function in filter cards to the showOrders function so it only shows when viewing all orders and not when a form is pulled up etc. 
- created the orderFilterStatusBtn under the events folder so I could listener to the user click on open or closed order and show those cards. 

## Related Issue
#59 

## Motivation and Context
-Allows the user to have more control over the orders they view. 

## How Can This Be Tested?
1. Make sure that the filter btn is only appearing in the all order pg and not in the forms, orderItems etc. 
2. when you click the open btn in the filter selection it should show all orders with the open status and vice versa. 
3. When orders are filtered the btn should still be on the left of your screen. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
