### PR TITLE
Revenue chart

### DIFF
--- a/api/revenueData.js
+++ b/api/revenueData.js
@@ -38,7 +38,7 @@ const getRevenueType = (uid) => new Promise((resolve, reject) => {
         const totalTips = array.map((item) => Number(item.tipAmount)).reduce((a, b) => a + b, 0);
         const totalRevenue = (revenue + totalTips).toFixed(2);
         resolve({
-          credit, mobile, cash, totalTips, totalRevenue
+          credit, mobile, cash, totalTips, totalRevenue, array
         });
       } else {
         resolve([]);

--- a/pages/showRevenue.js
+++ b/pages/showRevenue.js
@@ -14,7 +14,7 @@ const showRevenue = async (taco, uid) => {
   <h1 id="total-revenue" style="margin-bottom: 50px;">TOTAL REVENUE: $${taco.totalRevenue}</h1>
   <h5 id="date-range">Date Range: 01/01/2024 - 12/31/2024</h5>
   <br>
-  <p>TOTAL TIPS: $${taco.totalTips} </p>
+  <p>TOTAL TIPS: $${(taco.totalTips).toFixed(2)} </p>
   <p>TOTAL CALL IN ORDERS: ${callIn}</p>
   <p>TOTAL WALK IN ORDERS: ${walkIn}</p>
   <p>TOTAL ONLINE ORDERS: ${online}</p>
@@ -24,6 +24,34 @@ const showRevenue = async (taco, uid) => {
   <p>Credit: ${taco.credit} </p>
   <p>Mobile: ${taco.mobile} </p>
   </div>`;
+
+  domString += `<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">Total</th>
+      <th scope="col">Tip Amount</th>
+      <th scope="col">Payment Type</th>
+      <th scope="col">Time of Close Order</th>
+    </tr>
+  </thead>
+  <tbody class="table-group-divider">`;
+
+  // Having index in the forEach gets the index of the item in the array and then using the + 1 increments it everytime it goes through the loop
+  taco.array.forEach((revenue, index) => {
+    const rowNum = index + 1;
+    domString += `<tr>
+    <th scope="row">${rowNum}</th>
+    <td>${revenue.total}</td>
+    <td>${revenue.tipAmount}</td></td>
+    <td>${revenue.paymentType}</td>
+    <td>${revenue.timeSubmitted}</td>
+  </tr>`;
+  });
+
+  domString += `</tbody>
+  </table>`;
+
   renderToDom('#store', domString);
 };
 export default showRevenue;


### PR DESCRIPTION
## Description
A user should be able to see a table with all the close orders along with the overall total of all close orders with additional details.

## Related Issue
#62 

## Motivation and Context
This change is necessary to show every closed order that adds up to the total revenue. This helps to know if the total revenue is accurate and also how much each order usually is.

## How Can This Be Tested?
This can be tested by pressing view revenue on the login page and then you will see the table below total revenue and additional information.

## Screenshots (if appropriate):
![image](https://github.com/nss-evening-cohort-26/pos-terminal-the-algorithm-avengers/assets/153968439/ff1cd169-0f6e-4863-b3a0-ae441e010268)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
