### PR TITLE
Updated deleted order will not return delete button

### DIFF
--- a/events/formEvents.js
+++ b/events/formEvents.js
@@ -40,7 +40,6 @@ const formEvents = (uid) => {
         customer_name: document.querySelector('#customer_name').value,
         customer_email: document.querySelector('#customer_email').value,
         customer_phone: document.querySelector('#customer_phone').value,
-        status: true,
         timeSubmitted: new Date().toLocaleDateString('en-GB'),
         type: document.querySelector('#order-type').value,
         uid,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
A user can edit a closed order and should be able to update the order information and the order should not show the delete button.

## Related Issue
There is none.

## Motivation and Context
We want closed orders to remain closed and a closed order show not have a delete button when the order information is updated.

## How Can This Be Tested?
Update the details of an closed and see if the delete button shows up.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
